### PR TITLE
Fixing Safety concerning toXML() method -> No longer by Fields

### DIFF
--- a/src/main/java/io/github/oliviercailloux/y2018/apartments/toxmlproperties/XMLProperties.java
+++ b/src/main/java/io/github/oliviercailloux/y2018/apartments/toxmlproperties/XMLProperties.java
@@ -2,7 +2,6 @@ package io.github.oliviercailloux.y2018.apartments.toxmlproperties;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.lang.reflect.Field;
 import java.util.Properties;
 
 import org.slf4j.Logger;
@@ -33,18 +32,22 @@ public class XMLProperties {
 	 * @throws IllegalAccessException
 	 */
 	public void toXML(Apartment a, OutputStream xmlFile)
-			throws IOException, IllegalArgumentException, IllegalAccessException {
-
-		for (Field f : a.getClass().getDeclaredFields()) {
-
-			String[] fullName = f.toString().split(" ")[2].split("\\.");
-
-			f.setAccessible(true);
-			properties.setProperty(fullName[fullName.length - 1], f.get(a).toString());
-
-			LOGGER.info("Adding entry : " + fullName[fullName.length - 1] + " : " + f.get(a));
-
-		}
+			throws IOException {
+		
+		properties.setProperty("nbSleeping", String.valueOf(a.getNbSleeping()));
+		properties.setProperty("nbMinNight", String.valueOf(a.getNbMinNight()));
+		properties.setProperty("terrace", String.valueOf(a.getTerrace()));
+		properties.setProperty("nbBedrooms", String.valueOf(a.getNbBedrooms()));
+		properties.setProperty("floorArea", String.valueOf(a.getFloorArea()));
+		properties.setProperty("pricePerNight", String.valueOf(a.getPricePerNight()));
+		properties.setProperty("tele", String.valueOf(a.getTele()));
+		properties.setProperty("wifi", String.valueOf(a.getWifi()));
+		properties.setProperty("title", a.getTitle());
+		properties.setProperty("nbBathrooms", String.valueOf(a.getNbBathrooms()));
+		properties.setProperty("address", a.getAddress());
+		properties.setProperty("floorAreaTerrace", String.valueOf(a.getFloorAreaTerrace()));
+		properties.setProperty("description", a.getDescription());
+		
 		properties.remove("apartment");
 		properties.remove("LOGGER");
 		properties.remove("Logger");

--- a/src/main/java/io/github/oliviercailloux/y2018/apartments/toxmlproperties/XMLProperties.java
+++ b/src/main/java/io/github/oliviercailloux/y2018/apartments/toxmlproperties/XMLProperties.java
@@ -48,9 +48,6 @@ public class XMLProperties {
 		properties.setProperty("floorAreaTerrace", String.valueOf(a.getFloorAreaTerrace()));
 		properties.setProperty("description", a.getDescription());
 		
-		properties.remove("apartment");
-		properties.remove("LOGGER");
-		properties.remove("Logger");
 		properties.storeToXML(xmlFile, "Generated file for the apartment " + a.getTitle());
 
 		LOGGER.info("Stream has been closed");

--- a/src/test/resources/io/github/oliviercailloux/y2018/apartments/readApartments/xmlfileTest.xml
+++ b/src/test/resources/io/github/oliviercailloux/y2018/apartments/readApartments/xmlfileTest.xml
@@ -1,19 +1,18 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties>
-<comment>Generated file for the apartment Coucou</comment>
-<entry key="Logger">Logger[io.github.oliviercailloux.y2018.apartments.apartment.Apartment]</entry>
-<entry key="nbSleeping">0</entry>
-<entry key="nbMinNight">0</entry>
-<entry key="terrace">false</entry>
-<entry key="nbBedrooms">0</entry>
-<entry key="floorArea">200.0</entry>
-<entry key="pricePerNight">0.0</entry>
+<comment>Generated file for the apartment Grand Igloo</comment>
+<entry key="nbMinNight">1</entry>
+<entry key="wifi">true</entry>
+<entry key="address">118 rue du père noel 77480</entry>
+<entry key="floorAreaTerrace">8.6</entry>
+<entry key="nbBedrooms">5</entry>
+<entry key="description">Un igloo tout mignon en compagnie du père noël et de la mère noël</entry>
+<entry key="title">Grand Igloo</entry>
+<entry key="nbBathrooms">1</entry>
+<entry key="terrace">true</entry>
 <entry key="tele">false</entry>
-<entry key="wifi">false</entry>
-<entry key="title">Coucou</entry>
-<entry key="nbBathrooms">0</entry>
-<entry key="address">Chaville</entry>
-<entry key="description"/>
-<entry key="floorAreaTerrace">0.0</entry>
+<entry key="pricePerNight">404.0</entry>
+<entry key="floorArea">1182118.48</entry>
+<entry key="nbSleeping">10</entry>
 </properties>


### PR DESCRIPTION
Nous avons enlevé l'ancien fonctionnement de la méthode toXML() pour que les balises inscrites dans les fichiers restent les mêmes tant qu'un changement explicite dans le corps de la méthode n'est pas réalisé.

Nous avons également vérifié que les test unitaires fonctionnaient toujours avec cette nouvelle implémentation et c'est le cas.